### PR TITLE
=== rather than == / array destructuring in place of slice

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -137,12 +137,12 @@ export function hsep(
   docs: Array<Doc | string>,
   sep: Doc | string = space,
 ): Doc {
-  if (docs.length == 0) {
+  if (docs.length === 0) {
     return empty;
   } else {
     const docDocs = docs.map(toDoc);
 
-    if (docDocs.length == 1) {
+    if (docDocs.length === 1) {
       return docDocs[0];
     } else {
       return docDocs.slice(1).reduce((a, b) => a.pp(b, sep), docDocs[0]);
@@ -151,12 +151,12 @@ export function hsep(
 }
 
 export function hcat(docs: Array<Doc | string>): Doc {
-  if (docs.length == 0) {
+  if (docs.length === 0) {
     return empty;
   } else {
     const docDocs = docs.map(toDoc);
 
-    if (docDocs.length == 1) {
+    if (docDocs.length === 1) {
       return docDocs[0];
     } else {
       return docDocs.slice(1).reduce((a, b) => a.p(b), docDocs[0]);
@@ -178,7 +178,7 @@ export function punctuate(
   const last = docs.length;
   const docDocs = docs.map(toDoc);
 
-  if (last == 0 || last == 1) {
+  if (last === 0 || last === 1) {
     return docDocs;
   } else {
     const result = [];
@@ -208,7 +208,7 @@ export function join(
   separator: Doc | string = space,
   lastSeparator: Doc | string | undefined = undefined,
 ): Doc {
-  if (docs.length == 0) {
+  if (docs.length === 0) {
     return blank;
   } else {
     const result = [];
@@ -216,7 +216,7 @@ export function join(
     const docSeparator = toDoc(separator);
 
     while (true) {
-      if (index == docs.length - 1) {
+      if (index === docs.length - 1) {
         if (index > 0) {
           result.push(
             lastSeparator == undefined ? docSeparator : lastSeparator,
@@ -286,11 +286,11 @@ export function render(
         renderp(d.r, leftMargin, off, writer)
       );
     } else if (d instanceof PlusPlusDoc) {
-      if (d.l == empty && d.r == empty) {
+      if (d.l === empty && d.r === empty) {
         return Promise.resolve(offset);
-      } else if (d.l == empty) {
+      } else if (d.l === empty) {
         return renderp(d.r, leftMargin, offset, writer);
-      } else if (d.r == empty) {
+      } else if (d.r === empty) {
         return renderp(d.l, leftMargin, offset, writer);
       } else {
         return renderp(d.l, leftMargin, offset, writer).then((off) =>

--- a/mod.ts
+++ b/mod.ts
@@ -142,11 +142,10 @@ export function hsep(
   } else {
     const docDocs = docs.map(toDoc);
 
-    if (docDocs.length === 1) {
-      return docDocs[0];
-    } else {
-      return docDocs.slice(1).reduce((a, b) => a.pp(b, sep), docDocs[0]);
-    }
+    return docDocs.length === 1
+      ? docDocs[0]
+        // check out the ES6 destructuring gorgeousness! ref: https://stackoverflow.com/a/59411548/761388
+      : [ , ...docDocs].reduce((a, b) => a.pp(b, sep), docDocs[0]);
   }
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -142,10 +142,13 @@ export function hsep(
   } else {
     const docDocs = docs.map(toDoc);
 
-    return docDocs.length === 1
-      ? docDocs[0]
-        // check out the ES6 destructuring gorgeousness! ref: https://stackoverflow.com/a/59411548/761388
-      : [ , ...docDocs].reduce((a, b) => a.pp(b, sep), docDocs[0]);
+    if (docDocs.length === 1) {
+      return docDocs[0];
+    } 
+    
+    // oh the ES6 gorgeousness! https://stackoverflow.com/a/59411548/761388
+    const [theFirst, ...allButTheFirst] = docDocs;
+    return allButTheFirst.reduce((a, b) => a.p(b), theFirst);
   }
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -144,8 +144,8 @@ export function hsep(
 
     if (docDocs.length === 1) {
       return docDocs[0];
-    } 
-    
+    }
+
     // oh the ES6 gorgeousness! https://stackoverflow.com/a/59411548/761388
     const [theFirst, ...allButTheFirst] = docDocs;
     return allButTheFirst.reduce((a, b) => a.p(b), theFirst);

--- a/mod.ts
+++ b/mod.ts
@@ -148,7 +148,7 @@ export function hsep(
 
     // oh the ES6 gorgeousness! https://stackoverflow.com/a/59411548/761388
     const [theFirst, ...allButTheFirst] = docDocs;
-    return allButTheFirst.reduce((a, b) => a.p(b), theFirst);
+    return allButTheFirst.reduce((a, b) => a.pp(b, sep), theFirst);
   }
 }
 


### PR DESCRIPTION
Hey @graeme-lockley!

This is a PR that you can feel free to ignore!  But I thought it could be fun 😄 

I did this in the GitHub editor - I wish they'd hurry up and launch codespaces: https://github.com/features/codespaces

Nice use of GitHub Actions BTW!  It linted me the hard way. 

### Array destructuring in favour of `splice`

So there's some cools stuff you can do in JavaScript / TypeScript these days.  Where you would once have created a new array sans first element like so: 

```ts
docDocs.splice(1) //...
```

You can now do this using the ES6 destructuring gorgeousness! https://stackoverflow.com/a/59411548/761388

```ts
    const [theFirst, ...allButTheFirst] = docDocs;
    return allButTheFirst.reduce((a, b) => a.p(b), theFirst);
```

Which gives you a new array with all the elements but the first one, and puts the first one in a new variable to use.

It uses an extra line of code but it is for my money much clearer.  What do you think?

### Favouring `===`

I was wondering if you'd intended to use `==` instead of `===`?  You may not know about JavaScript's operator quirkiness, but the long story short is that if you'd use `!=` in another language you probably want `!==` in JS and where you'd use `==` in another language you probably want `===` in JS.  There's a better write up than I'd manage here:

https://stackoverflow.com/questions/359494/which-equals-operator-vs-should-be-used-in-javascript-comparisons

### Lovely stuff!

I really like your usage of `toDoc` directly with `.map` etc.  So pleasing to not need to introduce an anonymous function just for the purposes of calling on.

Also it's nice to see usage of `_` where you're ignoring a parameter in a function.  Completely subjective: I favour using a standalone variable rather than one wrapped by parens when there's only a single parameter in an arrow function.  Following the latest release of Prettier, the community is standardising on the approach you favour of having parens always:

```ts
// Input
const fn = (x) => y => x + y;

// Prettier 1.19
const fn = x => y => x + y;

// Prettier 2.0
const fn = (x) => (y) => x + y;
```

There's a good write up here: https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev

It makes sense - I'm going to move to it (but with gritted teeth 😄 )